### PR TITLE
Place wheels into directories based on wheel title

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,8 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.275
+    rev: v0.3.5
     hooks:
     -   id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
--   repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-    -   id: black
+    -   id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "safepull"
-version = "2.1.0"
+version = "2.1.1"
 description = "A CLI tool for downloading and extracting packages from PyPI without interfacing with setup.py."
 authors = ["Rem <128343390+import-pandas-as-numpy@users.noreply.github.com>"]
 license = "MIT"
@@ -26,4 +26,4 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 target-version = "py311"
 select = ["ALL"]
-ignore = ["ANN101", "ANN206", "ANN102"]
+ignore = ["ANN101", "ANN206", "ANN102", "S202"]

--- a/src/safepull/safepull.py
+++ b/src/safepull/safepull.py
@@ -1,9 +1,11 @@
 """Safepull module for the safe handling of compressed Python scripts."""
+
 # ruff: noqa: T201
 
 import argparse
 import tarfile
 from io import BytesIO
+from pathlib import Path
 from zipfile import ZipFile
 
 import requests
@@ -43,7 +45,7 @@ def unpack(byte_object: BytesIO, filename: str) -> None:
                     sdist_tar.extractall()
     if filename.endswith((".whl", ".zip")):
         with ZipFile(byte_object) as whl_zip:
-            whl_zip.extractall()
+            whl_zip.extractall(path=Path.cwd().joinpath(f"{filename[:-4]}"))
 
 
 def run() -> None:


### PR DESCRIPTION
Closes #86 
- Wheels will now be unpacked into a directory based on the wheel's title. 
- Updated Ruff pre-commit hook to placate Ruff's linter/formatting. 
- Removed Black due to a bit of redundancy and an interesting local conflict. 